### PR TITLE
Update debian, pip3 and geerlinguy's packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,12 +148,21 @@ You can also manually install the dependencies if your preferer.
 
 ### 3. Provision your local machine and deploy the example stack
 
+1. Copy `ansible/group_vars/localhost_overrides.sample.yml` to `ansible/group_vars/localhost_overrides.yml`  
+2. Add `ansible_user` variable with your user name
+
+```raw
+ansible_user: <yourUserName>
+```
+
+3. Provision and Deploy
+
 ```bash
 ./tads ansible-playbook localhost provision
 ./tads ansible-playbook localhost deploy
 ```
 
-The first command will:
+The first `./tads` command will:
 
 - Install Docker on your local machine
 - Set up a Swarm cluster with one manager node

--- a/ansible/provision-00-common.yml
+++ b/ansible/provision-00-common.yml
@@ -43,4 +43,10 @@
         key: "{{ item }}"
       with_items: "{{ docker_authorized_ssh_keys }}"
 
+    - name: Install Pip
+      become: True
+      apt:
+        name: python3-pip
+        update_cache: true
+
     # ADD YOUR OWN TASKS HERE

--- a/ansible/provision-01-docker.yml
+++ b/ansible/provision-01-docker.yml
@@ -9,6 +9,7 @@
   become: True
   roles:
     - role: geerlingguy.pip
+      pip_executable: pip3
       vars:
         pip_install_packages:
         - name: jsondiff # needed by Ansible docker_stack module

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -5,7 +5,7 @@
 ##
 
 - src: geerlingguy.pip
-  version: 1.3.0
+  version: 2.1.0
 
 - src: geerlingguy.docker
-  version: 2.5.2
+  version: 3.1.2

--- a/scripts/includes/ansible.sh
+++ b/scripts/includes/ansible.sh
@@ -16,7 +16,7 @@ check_ansible () {
     fi
 
     local current_ansible_version
-    current_ansible_version="$(ansible --version | head -n1 | cut -d " " -f2)"
+    current_ansible_version="$(ansible --version | head -n1 | cut -d " " -f3 | cut -c1-4)"
 
     if ! is_version_gte "${current_ansible_version}" "${TADS_MIN_ANSIBLE_VERSION}"; then
         echo_red "Your Ansible version (${current_ansible_version}) is not supported by T.A.D.S."

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -28,7 +28,7 @@ host_suffix = "vagrant-"
 Vagrant.configure("2") do |config|
   # ** Global config for all machines:
   # Use debian 9
-  config.vm.box = "debian/stretch64"
+  config.vm.box = "debian/bullseye64"
 
   # Disable default rsync of current host directory
   config.vm.synced_folder ".", "/vagrant", disabled: true


### PR DESCRIPTION
## Description
Update packages to handle new versions of geerlingguy.pip and geerlinguy.docker.
Handle pip3 for previous updates
Update debian image for vagrant deployment to use current stable release
Update ReadMe to support quick start out of the box as intended.

## Motivation and Context
The default instructions no longer work.

closes https://github.com/thomvaill/tads-boilerplate/issues/11

(Thank you @ivoba)


## How Has This Been Tested?
I have tested this in the vanilla repo as well as in my own application. 

NOTE: the `make test` all passes with the exception of the tests that rely on `shunit2.sh` but I believe this to be a separate issue related to @kward 's awesome https://github.com/kward/shunit2. Updating the `shunit2.sh` file to the new version was not a simple fix and I did not need to work through these to be confident in the small changes submitted in this pull request. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/Thomvaill/tads-boilerplate/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes. - *Not possible due to note above.*
- [ ] All new and existing tests passed. - *See note above*
