### PR TITLE
Adds tasks for installing dependencies on Mac

### DIFF
--- a/ansible/install-dependencies.yml
+++ b/ansible/install-dependencies.yml
@@ -34,6 +34,7 @@
         name: "{{ item }}"
         state: present
       with_items:
+        - coreutils # for GNU ls
         - jq
       when: ansible_facts['os_family'] == "Darwin"
 

--- a/ansible/install-dependencies.yml
+++ b/ansible/install-dependencies.yml
@@ -7,7 +7,7 @@
 
 - hosts: localhost
   tasks:
-    - name: Install Vagrant, Virtualbox and other dependencies
+    - name: Install Vagrant, Virtualbox and other dependencies (linux)
       become: yes
       package:
         name: "{{ item }}"
@@ -16,8 +16,28 @@
         - virtualbox
         - vagrant
         - jq
+      when: ansible_facts['os_family'] != "Darwin"
 
-    - name: Install Terraform
+    - name: Install Vagrant & Virtualbox (mac)
+      become: no
+      homebrew_cask:
+        name: "{{ item }}"
+        state: present
+      with_items:
+        - virtualbox
+        - vagrant
+      when: ansible_facts['os_family'] == "Darwin"
+
+    - name: Other dependencies (mac)
+      become: no
+      homebrew:
+        name: "{{ item }}"
+        state: present
+      with_items:
+        - jq
+      when: ansible_facts['os_family'] == "Darwin"
+
+    - name: Install Terraform (linux)
       shell: >
         wget -O /tmp/terraform.zip "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
         && unzip -d ~/.local/bin /tmp/terraform.zip
@@ -27,6 +47,19 @@
       args:
         creates: ~/.local/bin/terraform
         warn: False
+      when: ansible_facts['os_family'] != "Darwin"
+
+    - name: Install Terraform Homebrew Tap (Mac)
+      homebrew_tap:
+        name: hashicorp/tap
+        state: present
+      when: ansible_facts['os_family'] == "Darwin"
+
+    - name: Install Terraform (Mac)
+      homebrew:
+        name: hashicorp/tap/terraform
+        state: present
+      when: ansible_facts['os_family'] == "Darwin"
 
 - hosts: localhost
   tags:

--- a/scripts/commands/install-dependencies.sh
+++ b/scripts/commands/install-dependencies.sh
@@ -62,14 +62,20 @@ main () {
 
     echo "Installing Ansible..."
     if ! command -v ansible > /dev/null; then
-        echo "Your SUDO password may be asked"
+        if command -v apt-get > /dev/null; then
+            echo "Your SUDO password may be asked"
 
-        [[ "${TADS_VERBOSE:-}" == true ]] &&  set -x
-        sudo apt-get update \
-        && sudo apt-get --yes install software-properties-common \
-        && sudo apt-add-repository --yes --update ppa:ansible/ansible \
-        && sudo apt-get --yes install ansible
-        set +x
+            [[ "${TADS_VERBOSE:-}" == true ]] &&  set -x
+            sudo apt-get update \
+            && sudo apt-get --yes install software-properties-common \
+            && sudo apt-add-repository --yes --update ppa:ansible/ansible \
+            && sudo apt-get --yes install ansible
+            set +x
+        else
+            echo "Unable to work out how to install Ansible.  Either install it first, manually,"
+            echo "or update the ${SELF_PATH}/${SELF_NAME} script"
+            echo "to support installing automatically on your OS."
+        fi
     else
         echo "Ansible is already installed. Skipping"
     fi

--- a/scripts/includes/ansible.sh
+++ b/scripts/includes/ansible.sh
@@ -6,7 +6,12 @@ readonly TADS_MIN_ANSIBLE_VERSION="2.8"
 export ANSIBLE_DEPRECATION_WARNINGS="False"
 
 get_ansible_remote_environments () {
-    ls -1 -I "localhost" -I "*.sample*" "${ROOT_PATH}/ansible/inventories"
+    # Test for Mac GNU ls command (installed in `ansible/install-dependencies.yml`)
+    if [ -f /usr/local/opt/coreutils/libexec/gnubin/ls ] ; then
+        /usr/local/opt/coreutils/libexec/gnubin/ls -1 -I "localhost" -I "*.sample*" "${ROOT_PATH}/ansible/inventories"
+    else
+        ls -1 -I "localhost" -I "*.sample*" "${ROOT_PATH}/ansible/inventories"
+    fi
 }
 
 check_ansible () {


### PR DESCRIPTION
This detects the 'Darwin' OS family, and uses homebrew to install the dependencies if so.

## Description

Splits out the steps for installing the following dependencies between Mac & linux…

- Vagrant
- VirtualBox
- jq
- Terraform

Then uses the homebrew & homebrew_cask modules to install the dependencies when on a Mac.

More changes are needed to get full Mac support, so perhaps you would prefer a new 'mac-support' development branch be targeted by this PR?


## Motivation and Context

I'm using tads-boilerplate on a Mac, so using `become: yes` on the standardised `package` module fails with a warning about running as root, and Vagrant & VirtualBox need are casks, rather than standard homebrew packages, so I had to use homebrew_cask to install them.

We would also need to update the `scripts/commands/install-dependencies.sh` to install Ansible in a Mac way, but for now I've added a message to manually install this, if this is acceptable?


## How Has This Been Tested?

I have run these on MacOS 12.6 and Ansible confirmed they were installed.  I've not yet tested it will install them, however if there is an appetite for this PR I will remove those applications and re-test.


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - Should I update the docs to suggest this now supports Mac, as there are other changes that are likely needed first?
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/Thomvaill/tads-boilerplate/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
  - I'm not sure how to do this
- [ ] All new and existing tests passed.
